### PR TITLE
add ata-29-11

### DIFF
--- a/docs/atas/reuniao-com-time/ata_29_11_22.md
+++ b/docs/atas/reuniao-com-time/ata_29_11_22.md
@@ -1,0 +1,18 @@
+# Ata reunião 29/11/2022
+
+**Presentes**: Eduarda, Emily, João, Gabriel, Gustavo, Marcelo, Thiago, Washignton, Gustavo, Wallyson e Weslley.</br>
+**Local**: Call pelo Discord. </br>
+**Objetivo**: finalização do Lean Inception a partir das funcionalidades validadas.</br>
+
+# Descrição:
+
+- A equipe debateu os esforços, negócios e UX das funcionalidades validadas (revisão técnica, de negócio e UX);
+- Estimou para montar o sequenciador;
+- Definiu o MVP canvas;
+- Marcou a próxima reunião para montar o backlog e fazer um Dojo de testes.
+
+## Versionamento
+
+|    Data    | Versão |       Descrição       |                  Autor                   |
+| :--------: | :----: | :-------------------: | :--------------------------------------: |
+| 29/11/2022 |  1.0   | Criação do documento  | [Eduarda](https://github.com/ServidioEC) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
       - Ata (17/11/2022): atas/reuniao-com-time/ata_17_11_22.md
       - Ata (19/11/2022): atas/reuniao-com-time/ata_19_11_22.md
       - Ata (23/11/2022): atas/reuniao-com-time/ata_23_11_22.md
+      - Ata (29/11/2022): atas/reuniao-com-time/ata_29_11_22.md
     - Reunião com o cliente:
       - Ata (11/11/2022): atas/reuniao-com-cliente/ata_11_11_22.md
       - Ata (18/11/2022): atas/reuniao-com-cliente/ata_18_11_22.md


### PR DESCRIPTION
Adição da ata da reunião do time em 19/11/2022, onde debateu-se as etapas finais do Lean Inception: Revisão Técnica, de Negócio e UX; Sequenciador e Canvas.